### PR TITLE
chore: upgrade Tauri to 2.8.x and related packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,16 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.0",
-    "@tauri-apps/api": "^2.2.0",
-    "@tauri-apps/plugin-notification": "^2.2.1",
+    "@tauri-apps/api": "^2.8.0",
+    "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-window": "^2.0.0-alpha.1",
     "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.0"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.2.7",
+    "@tauri-apps/cli": "^2.8.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/parser": "^8.26.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,10 +18,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2.8.2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.33.1"
-tauri-plugin-notification = "2.2.1"
-
+tauri-plugin-notification = "2"


### PR DESCRIPTION
Summary\n- Upgrade Rust crates:\n  - tauri = 2.8.2\n  - tauri-build = "2" (track latest 2.x due to crate availability)\n  - tauri-plugin-notification = "2"\n  - tauri-plugin-opener = "2"\n- Update JS packages:\n  - @tauri-apps/api -> ^2.8.0\n  - @tauri-apps/cli -> ^2.8.1\n  - @tauri-apps/plugin-notification -> ^2\n  - @tauri-apps/plugin-opener -> ^2\n- Remove stale @tauri-apps/plugin-window alpha dep (unused).\n\nRationale\nBrings in recent windowing/runtime fixes in Tauri 2.8.x, including improved behavior moving windows across monitors.\n\nTesting\n- yarn install\n- cargo build --release (or yarn tauri build)\n- Manually drag the app window between monitors (different scale factors) to confirm correct behavior.\n\nNotes\n- No tauri.conf.json changes required.\n- tauri-build pinned to major 2 to avoid version resolution issues with non-existent 2.8.2 build crate on crates.io.